### PR TITLE
Fix dependencies, warnings and verbose messages

### DIFF
--- a/gotham-client/Cargo.toml
+++ b/gotham-client/Cargo.toml
@@ -21,13 +21,14 @@ time = "*"
 clap = { version = "2.32", features = ["yaml"] }
 reqwest = "0.9.5"
 uuid = { version = "0.7", features = ["v4"] }
-bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin" }
 electrumx_client = { git = "https://github.com/evgeniy-scherbina/rust-electrumx-client" }
 itertools = "0.8.0"
 hex = "0.3.2"
+bitcoin = "0.16.0"
+config = "0.9"
 
 [dependencies.secp256k1]
-version = "0.11.1"
+version = "0.12"
 features = ["rand", "serde"]
 
 [dependencies.zk-paillier]

--- a/gotham-client/src/wallet/mod.rs
+++ b/gotham-client/src/wallet/mod.rs
@@ -33,7 +33,6 @@ use super::utilities::requests;
 use curv::arithmetic::traits::Converter;
 use hex;
 use itertools::Itertools;
-use secp256k1::Secp256k1;
 use secp256k1::Signature;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -319,10 +318,7 @@ impl Wallet {
             let mut v = BigInt::to_vec(&signatures.r);
             v.extend(BigInt::to_vec(&signatures.s));
 
-            let context = Secp256k1::new();
-            let mut sig = Signature::from_compact(&context, &v[..])
-                .unwrap()
-                .serialize_der(&context);
+            let mut sig = Signature::from_compact(&v[..]).unwrap().serialize_der();
 
             sig.push(01);
             let mut witness = Vec::new();

--- a/gotham-server/src/lib.rs
+++ b/gotham-server/src/lib.rs
@@ -32,7 +32,6 @@ extern crate strum_macros;
 #[macro_use]
 extern crate log;
 
-#[macro_use]
 extern crate time_test;
 extern crate time;
 

--- a/gotham-server/src/tests.rs
+++ b/gotham-server/src/tests.rs
@@ -7,328 +7,336 @@
 // version 3 of the License, or (at your option) any later version.
 //
 
-use super::routes::ecdsa;
-use super::server;
-use rocket;
-use rocket::http::ContentType;
-use rocket::http::Status;
-use rocket::local::Client;
-use serde_json;
-use time::PreciseTime;
+#[cfg(test)]
+mod tests {
 
-use curv::arithmetic::traits::Converter;
-use curv::cryptographic_primitives::twoparty::dh_key_exchange::*;
-use curv::BigInt;
-use kms::chain_code::two_party as chain_code;
-use kms::ecdsa::two_party::*;
-use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::*;
-use zk_paillier::zkproofs::*;
+    use super::routes::ecdsa;
+    use super::server;
+    use rocket;
+    use rocket::http::ContentType;
+    use rocket::http::Status;
+    use rocket::local::Client;
+    use serde_json;
+    use time::PreciseTime;
 
-fn key_gen(client: &Client) -> (String, MasterKey2) {
-    time_test!();
+    use curv::arithmetic::traits::Converter;
+    use curv::cryptographic_primitives::twoparty::dh_key_exchange::*;
+    use curv::BigInt;
+    use kms::chain_code::two_party as chain_code;
+    use kms::ecdsa::two_party::*;
+    use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::*;
 
-    /*************** START: FIRST MESSAGE ***************/
-    let start = PreciseTime::now();
+    fn key_gen(client: &Client) -> (String, MasterKey2) {
+        time_test!();
 
-    let mut response = client
-        .post("/ecdsa/keygen/first")
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
+        /*************** START: FIRST MESSAGE ***************/
+        let start = PreciseTime::now();
 
-    let end = PreciseTime::now();
-    println!("{} Network/Server: party1 first message", start.to(end));
+        let mut response = client
+            .post("/ecdsa/keygen/first")
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
 
-    let res_body = response.body_string().unwrap();
-    let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
-        serde_json::from_str(&res_body).unwrap();
+        let end = PreciseTime::now();
+        println!("{} Network/Server: party1 first message", start.to(end));
 
-    let start = PreciseTime::now();
+        let res_body = response.body_string().unwrap();
+        let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
+            serde_json::from_str(&res_body).unwrap();
 
-    let (kg_party_two_first_message, kg_ec_key_pair_party2) = MasterKey2::key_gen_first_message();
+        let start = PreciseTime::now();
 
-    let end = PreciseTime::now();
-    println!("{} Client: party2 first message", start.to(end));
-    /*************** END: FIRST MESSAGE ***************/
+        let (kg_party_two_first_message, kg_ec_key_pair_party2) = MasterKey2::key_gen_first_message();
 
-    /*************** START: SECOND MESSAGE ***************/
-    let body = serde_json::to_string(&kg_party_two_first_message.d_log_proof).unwrap();
+        let end = PreciseTime::now();
+        println!("{} Client: party2 first message", start.to(end));
+        /*************** END: FIRST MESSAGE ***************/
 
-    let start = PreciseTime::now();
+        /*************** START: SECOND MESSAGE ***************/
+        let body = serde_json::to_string(&kg_party_two_first_message.d_log_proof).unwrap();
 
-    let mut response = client
-        .post(format!("/ecdsa/keygen/{}/second", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
+        let start = PreciseTime::now();
 
-    let end = PreciseTime::now();
-    println!("{} Network/Server: party1 second message", start.to(end));
+        let mut response = client
+            .post(format!("/ecdsa/keygen/{}/second", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
 
-    let res_body = response.body_string().unwrap();
-    let kg_party_one_second_message: party1::KeyGenParty1Message2 =
-        serde_json::from_str(&res_body).unwrap();
-
-    let start = PreciseTime::now();
-
-    let key_gen_second_message = MasterKey2::key_gen_second_message(
-        &kg_party_one_first_message,
-        &kg_party_one_second_message,
-    );
-    assert!(key_gen_second_message.is_ok());
+        let end = PreciseTime::now();
+        println!("{} Network/Server: party1 second message", start.to(end));
 
-    let end = PreciseTime::now();
-    println!("{} Client: party2 second message", start.to(end));
-
-    let (party_two_second_message, party_two_paillier, party_two_pdl_chal) =
-        key_gen_second_message.unwrap();
-    /*************** END: SECOND MESSAGE ***************/
-
-    /*************** START: THIRD MESSAGE ***************/
-    let body = serde_json::to_string(&party_two_second_message.pdl_first_message).unwrap();
-
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/keygen/{}/third", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!("{} Network/Server: party1 third message", start.to(end));
-
-    let res_body = response.body_string().unwrap();
-    let party_one_third_message: party_one::PDLFirstMessage =
-        serde_json::from_str(&res_body).unwrap();
-
-    let start = PreciseTime::now();
-
-    let pdl_decom_party2 = MasterKey2::key_gen_third_message(&party_two_pdl_chal);
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 third message", start.to(end));
-    /*************** END: THIRD MESSAGE ***************/
-
-    /*************** START: FOURTH MESSAGE ***************/
-
-    let party_2_pdl_second_message = pdl_decom_party2;
-    let request = party_2_pdl_second_message;
-    let body = serde_json::to_string(&request).unwrap();
-
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/keygen/{}/fourth", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!("{} Network/Server: party1 fourth message", start.to(end));
-
-    let res_body = response.body_string().unwrap();
-    let party_one_pdl_second_message: party_one::PDLSecondMessage =
-        serde_json::from_str(&res_body).unwrap();
-
-    let start = PreciseTime::now();
-
-    MasterKey2::key_gen_fourth_message(
-        &party_two_pdl_chal,
-        &party_one_third_message,
-        &party_one_pdl_second_message,
-    )
-    .expect("pdl error party1");
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 fourth message", start.to(end));
-    /*************** END: FOURTH MESSAGE ***************/
-
-    /*************** START: CHAINCODE FIRST MESSAGE ***************/
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/keygen/{}/chaincode/first", id))
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!(
-        "{} Network/Server: party1 chain code first message",
-        start.to(end)
-    );
-
-    let res_body = response.body_string().unwrap();
-    let cc_party_one_first_message: Party1FirstMessage = serde_json::from_str(&res_body).unwrap();
-
-    let start = PreciseTime::now();
-    let (cc_party_two_first_message, cc_ec_key_pair2) =
-        chain_code::party2::ChainCode2::chain_code_first_message();
-    let end = PreciseTime::now();
-    println!("{} Client: party2 chain code first message", start.to(end));
-    /*************** END: CHAINCODE FIRST MESSAGE ***************/
-
-    /*************** START: CHAINCODE SECOND MESSAGE ***************/
-    let body = serde_json::to_string(&cc_party_two_first_message.d_log_proof).unwrap();
-
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/keygen/{}/chaincode/second", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!(
-        "{} Network/Server: party1 chain code second message",
-        start.to(end)
-    );
-
-    let res_body = response.body_string().unwrap();
-    let cc_party_one_second_message: Party1SecondMessage = serde_json::from_str(&res_body).unwrap();
-
-    let start = PreciseTime::now();
-    let cc_party_two_second_message = chain_code::party2::ChainCode2::chain_code_second_message(
-        &cc_party_one_first_message,
-        &cc_party_one_second_message,
-    );
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 chain code second message", start.to(end));
-    /*************** END: CHAINCODE SECOND MESSAGE ***************/
-
-    let start = PreciseTime::now();
-    let party2_cc = chain_code::party2::ChainCode2::compute_chain_code(
-        &cc_ec_key_pair2,
-        &cc_party_one_second_message.comm_witness.public_share,
-    );
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 chain code second message", start.to(end));
-    /*************** END: CHAINCODE COMPUTE MESSAGE ***************/
-
-    let end = PreciseTime::now();
-    println!("{} Network/Server: party1 master key", start.to(end));
-
-    let start = PreciseTime::now();
-    let party_two_master_key = MasterKey2::set_master_key(
-        &party2_cc.chain_code,
-        &kg_ec_key_pair_party2,
-        &kg_party_one_second_message
-            .ecdh_second_message
-            .comm_witness
-            .public_share,
-        &party_two_paillier,
-    );
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 master_key", start.to(end));
-    /*************** END: MASTER KEYS MESSAGE ***************/
-
-    (id, party_two_master_key)
-}
-
-pub fn sign(
-    client: &Client,
-    id: String,
-    master_key_2: MasterKey2,
-    message: BigInt,
-) -> party_one::Signature {
-    time_test!();
-
-    let start = PreciseTime::now();
-    let (eph_key_gen_first_message_party_two, eph_comm_witness, eph_ec_key_pair_party2) =
-        MasterKey2::sign_first_message();
-
-    let request: party_two::EphKeyGenFirstMsg = eph_key_gen_first_message_party_two;
-
-    let body = serde_json::to_string(&request).unwrap();
-
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/sign/{}/first", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!(
-        "{} Network/Server: party1 sign first message",
-        start.to(end)
-    );
-
-    let res_body = response.body_string().unwrap();
-    let sign_party_one_first_message: party_one::EphKeyGenFirstMsg =
-        serde_json::from_str(&res_body).unwrap();
-
-    let pos = 1;
-
-    let child_party_two_master_key = master_key_2.get_child(vec![BigInt::from(pos)]);
-
-    let start = PreciseTime::now();
-
-    let party_two_sign_message = child_party_two_master_key.sign_second_message(
-        &eph_ec_key_pair_party2,
-        eph_comm_witness.clone(),
-        &sign_party_one_first_message,
-        &message,
-    );
-
-    let end = PreciseTime::now();
-    println!("{} Client: party2 sign second message", start.to(end));
-
-    let request: ecdsa::SignSecondMsgRequest = ecdsa::SignSecondMsgRequest {
-        message,
-        party_two_sign_message,
-        pos_child_key: 1,
-    };
-
-    let body = serde_json::to_string(&request).unwrap();
-
-    let start = PreciseTime::now();
-
-    let mut response = client
-        .post(format!("/ecdsa/sign/{}/second", id))
-        .body(body)
-        .header(ContentType::JSON)
-        .dispatch();
-    assert_eq!(response.status(), Status::Ok);
-
-    let end = PreciseTime::now();
-    println!(
-        "{} Network/Server: party1 sign second message",
-        start.to(end)
-    );
-
-    let res_body = response.body_string().unwrap();
-    let signatures: party_one::Signature = serde_json::from_str(&res_body).unwrap();
-
-    signatures
-}
-
-#[test]
-fn key_gen_and_sign() {
-    time_test!();
-
-    let client = Client::new(server::get_server()).expect("valid rocket instance");
-
-    let (id, master_key_2): (String, MasterKey2) = key_gen(&client);
-
-    let message = BigInt::from(1234);
-
-    let signatures: party_one::Signature = sign(&client, id, master_key_2, message);
-
-    println!(
-        "s = (r: {}, s: {})",
-        signatures.r.to_hex(),
-        signatures.s.to_hex()
-    );
+        let res_body = response.body_string().unwrap();
+        let kg_party_one_second_message: party1::KeyGenParty1Message2 =
+            serde_json::from_str(&res_body).unwrap();
+
+        let start = PreciseTime::now();
+
+        let key_gen_second_message = MasterKey2::key_gen_second_message(
+            &kg_party_one_first_message,
+            &kg_party_one_second_message,
+        );
+        assert!(key_gen_second_message.is_ok());
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 second message", start.to(end));
+
+        let (party_two_second_message, party_two_paillier, party_two_pdl_chal) =
+            key_gen_second_message.unwrap();
+        /*************** END: SECOND MESSAGE ***************/
+
+        /*************** START: THIRD MESSAGE ***************/
+        let body = serde_json::to_string(&party_two_second_message.pdl_first_message).unwrap();
+
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/keygen/{}/third", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!("{} Network/Server: party1 third message", start.to(end));
+
+        let res_body = response.body_string().unwrap();
+        let party_one_third_message: party_one::PDLFirstMessage =
+            serde_json::from_str(&res_body).unwrap();
+
+        let start = PreciseTime::now();
+
+        let pdl_decom_party2 = MasterKey2::key_gen_third_message(&party_two_pdl_chal);
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 third message", start.to(end));
+        /*************** END: THIRD MESSAGE ***************/
+
+        /*************** START: FOURTH MESSAGE ***************/
+
+        let party_2_pdl_second_message = pdl_decom_party2;
+        let request = party_2_pdl_second_message;
+        let body = serde_json::to_string(&request).unwrap();
+
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/keygen/{}/fourth", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!("{} Network/Server: party1 fourth message", start.to(end));
+
+        let res_body = response.body_string().unwrap();
+        let party_one_pdl_second_message: party_one::PDLSecondMessage =
+            serde_json::from_str(&res_body).unwrap();
+
+        let start = PreciseTime::now();
+
+        MasterKey2::key_gen_fourth_message(
+            &party_two_pdl_chal,
+            &party_one_third_message,
+            &party_one_pdl_second_message,
+        )
+            .expect("pdl error party1");
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 fourth message", start.to(end));
+        /*************** END: FOURTH MESSAGE ***************/
+
+        /*************** START: CHAINCODE FIRST MESSAGE ***************/
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/keygen/{}/chaincode/first", id))
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!(
+            "{} Network/Server: party1 chain code first message",
+            start.to(end)
+        );
+
+        let res_body = response.body_string().unwrap();
+        let cc_party_one_first_message: Party1FirstMessage = serde_json::from_str(&res_body).unwrap();
+
+        let start = PreciseTime::now();
+        let (cc_party_two_first_message, cc_ec_key_pair2) =
+            chain_code::party2::ChainCode2::chain_code_first_message();
+        let end = PreciseTime::now();
+        println!("{} Client: party2 chain code first message", start.to(end));
+        /*************** END: CHAINCODE FIRST MESSAGE ***************/
+
+        /*************** START: CHAINCODE SECOND MESSAGE ***************/
+        let body = serde_json::to_string(&cc_party_two_first_message.d_log_proof).unwrap();
+
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/keygen/{}/chaincode/second", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!(
+            "{} Network/Server: party1 chain code second message",
+            start.to(end)
+        );
+
+        let res_body = response.body_string().unwrap();
+        let cc_party_one_second_message: Party1SecondMessage = serde_json::from_str(&res_body).unwrap();
+
+        let start = PreciseTime::now();
+        let _cc_party_two_second_message = chain_code::party2::ChainCode2::chain_code_second_message(
+            &cc_party_one_first_message,
+            &cc_party_one_second_message,
+        );
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 chain code second message", start.to(end));
+        /*************** END: CHAINCODE SECOND MESSAGE ***************/
+
+        let start = PreciseTime::now();
+        let party2_cc = chain_code::party2::ChainCode2::compute_chain_code(
+            &cc_ec_key_pair2,
+            &cc_party_one_second_message.comm_witness.public_share,
+        );
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 chain code second message", start.to(end));
+        /*************** END: CHAINCODE COMPUTE MESSAGE ***************/
+
+        let end = PreciseTime::now();
+        println!("{} Network/Server: party1 master key", start.to(end));
+
+        let start = PreciseTime::now();
+        let party_two_master_key = MasterKey2::set_master_key(
+            &party2_cc.chain_code,
+            &kg_ec_key_pair_party2,
+            &kg_party_one_second_message
+                .ecdh_second_message
+                .comm_witness
+                .public_share,
+            &party_two_paillier,
+        );
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 master_key", start.to(end));
+        /*************** END: MASTER KEYS MESSAGE ***************/
+
+        (id, party_two_master_key)
+    }
+
+    pub fn sign(
+        client: &Client,
+        id: String,
+        master_key_2: MasterKey2,
+        message: BigInt,
+    ) -> party_one::Signature {
+        time_test!();
+
+        let start = PreciseTime::now();
+        let (eph_key_gen_first_message_party_two, eph_comm_witness, eph_ec_key_pair_party2) =
+            MasterKey2::sign_first_message();
+        let end = PreciseTime::now();
+        println!(
+            "{} Client: party2 sign first message",
+            start.to(end)
+        );
+
+        let request: party_two::EphKeyGenFirstMsg = eph_key_gen_first_message_party_two;
+
+        let body = serde_json::to_string(&request).unwrap();
+
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/sign/{}/first", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!(
+            "{} Network/Server: party1 sign first message",
+            start.to(end)
+        );
+
+        let res_body = response.body_string().unwrap();
+        let sign_party_one_first_message: party_one::EphKeyGenFirstMsg =
+            serde_json::from_str(&res_body).unwrap();
+
+        let pos = 1;
+
+        let child_party_two_master_key = master_key_2.get_child(vec![BigInt::from(pos)]);
+
+        let start = PreciseTime::now();
+
+        let party_two_sign_message = child_party_two_master_key.sign_second_message(
+            &eph_ec_key_pair_party2,
+            eph_comm_witness.clone(),
+            &sign_party_one_first_message,
+            &message,
+        );
+
+        let end = PreciseTime::now();
+        println!("{} Client: party2 sign second message", start.to(end));
+
+        let request: ecdsa::SignSecondMsgRequest = ecdsa::SignSecondMsgRequest {
+            message,
+            party_two_sign_message,
+            pos_child_key: 1,
+        };
+
+        let body = serde_json::to_string(&request).unwrap();
+
+        let start = PreciseTime::now();
+
+        let mut response = client
+            .post(format!("/ecdsa/sign/{}/second", id))
+            .body(body)
+            .header(ContentType::JSON)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let end = PreciseTime::now();
+        println!(
+            "{} Network/Server: party1 sign second message",
+            start.to(end)
+        );
+
+        let res_body = response.body_string().unwrap();
+        let signatures: party_one::Signature = serde_json::from_str(&res_body).unwrap();
+
+        signatures
+    }
+
+    #[test]
+    fn key_gen_and_sign() {
+        time_test!();
+
+        let client = Client::new(server::get_server()).expect("valid rocket instance");
+
+        let (id, master_key_2): (String, MasterKey2) = key_gen(&client);
+
+        let message = BigInt::from(1234);
+
+        let signatures: party_one::Signature = sign(&client, id, master_key_2, message);
+
+        println!(
+            "s = (r: {}, s: {})",
+            signatures.r.to_hex(),
+            signatures.s.to_hex()
+        );
+    }
 }

--- a/gotham-server/src/utilities/db.rs
+++ b/gotham-server/src/utilities/db.rs
@@ -22,7 +22,7 @@ where
 {
     let identifier = idify(id, name);
     let v: String = serde_json::to_string(&v).unwrap();
-    info!("Inserting into db ({}, {})", identifier, v);
+    debug!("Inserting into db ({}, {})", identifier, v);
 
     let r = db.put(identifier.as_ref(), v.as_ref());
     if r.is_err() {
@@ -32,7 +32,7 @@ where
 
 pub fn get(db: &DB, id: &String, name: &ecdsa::Share) -> Option<DBVector> {
     let identifier = idify(id, name);
-    info!("Getting from db ({})", identifier);
+    debug!("Getting from db ({})", identifier);
 
     let r = db.get(identifier.as_ref());
     if r.is_err() {


### PR DESCRIPTION
- Due to the flexible `bitcoin` dependency, build broke. This PR fixes the version.
- DB access messages to `debug!` instead of `info!` so they will not appear on screen by default.
- wrapped tests as module so unused warnings will not appear when building.