### PR TITLE
Resolving npm packages vulnerabilities

### DIFF
--- a/gotham-utilities/server/cognito/package-lock.json
+++ b/gotham-utilities/server/cognito/package-lock.json
@@ -200,9 +200,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",

--- a/gotham-utilities/server/cognito/package.json
+++ b/gotham-utilities/server/cognito/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "jwk-to-pem": "^2.0.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "node-fetch": "^2.3.0",
     "rsa-key": "0.0.6",
     "yargs": "^12.0.5"


### PR DESCRIPTION
Updating `lodash` package to the latest version (4.17.15).