### PR TITLE
fix compilation errors + Travis CI for specified nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 rust:
-  - nightly-2019-07-09
+  - nightly-2019-07-10
 
 script:
   - cd integration-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+cache: cargo
+rust:
+  - nightly-2019-07-09
+
+script:
+  - cd integration-tests
+  - cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/KZen-networks/gotham-city.svg?branch=master)](https://travis-ci.com/KZen-networks/gotham-city)
+
 Gotham City
 =====================================
 Gotham city is a fully functional client/server application of a minimalist decentralized HD wallet using 2 party ECDSA.

--- a/gotham-client/Cargo.toml
+++ b/gotham-client/Cargo.toml
@@ -21,7 +21,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 log = "0.4"
-time = "*"
 clap = { version = "2.32", features = ["yaml"] }
 reqwest = "0.9.5"
 failure = "0.1.5"

--- a/gotham-client/Cargo.toml
+++ b/gotham-client/Cargo.toml
@@ -30,6 +30,7 @@ itertools = "0.8.0"
 hex = "0.3.2"
 bitcoin = "0.20.0"
 config = "0.9"
+floating-duration = "0.1.2"
 
 [dependencies.zk-paillier]
 git = "https://github.com/KZen-networks/zk-paillier"

--- a/gotham-client/src/ecdsa/keygen.rs
+++ b/gotham-client/src/ecdsa/keygen.rs
@@ -8,7 +8,7 @@
 //
 
 use serde_json;
-use time::PreciseTime;
+use std::time::Instant;
 
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 use kms::chain_code::two_party as chain_code;
@@ -26,7 +26,7 @@ use std::os::raw::c_char;
 const KG_PATH_PRE: &str = "ecdsa/keygen";
 
 pub fn get_master_key(client_shim: &ClientShim) -> PrivateShare {
-    let start = PreciseTime::now();
+    let start = Instant::now();
 
     let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
         requests::post(client_shim, &format!("{}/first", KG_PATH_PRE)).unwrap();
@@ -108,8 +108,7 @@ pub fn get_master_key(client_shim: &ClientShim) -> PrivateShare {
         &party_two_paillier,
     );
 
-    let end = PreciseTime::now();
-    println!("(id: {}) Took: {}", id, start.to(end));
+    println!("(id: {}) Took: {}", id, start.elapsed().as_secs());
 
     PrivateShare { id, master_key }
 }

--- a/gotham-client/src/ecdsa/keygen.rs
+++ b/gotham-client/src/ecdsa/keygen.rs
@@ -9,7 +9,7 @@
 
 use serde_json;
 use std::time::Instant;
-use floating_duration::TimeAsFloat;
+use floating_duration::TimeFormat;
 
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 use kms::chain_code::two_party as chain_code;
@@ -109,7 +109,7 @@ pub fn get_master_key(client_shim: &ClientShim) -> PrivateShare {
         &party_two_paillier,
     );
 
-    println!("(id: {}) Took: {}", id, start.elapsed().as_fractional_secs());
+    println!("(id: {}) Took: {}", id, TimeFormat(start.elapsed()));
 
     PrivateShare { id, master_key }
 }

--- a/gotham-client/src/ecdsa/keygen.rs
+++ b/gotham-client/src/ecdsa/keygen.rs
@@ -9,6 +9,7 @@
 
 use serde_json;
 use std::time::Instant;
+use floating_duration::TimeAsFloat;
 
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 use kms::chain_code::two_party as chain_code;
@@ -108,7 +109,7 @@ pub fn get_master_key(client_shim: &ClientShim) -> PrivateShare {
         &party_two_paillier,
     );
 
-    println!("(id: {}) Took: {}", id, start.elapsed().as_secs());
+    println!("(id: {}) Took: {}", id, start.elapsed().as_fractional_secs());
 
     PrivateShare { id, master_key }
 }

--- a/gotham-client/src/lib.rs
+++ b/gotham-client/src/lib.rs
@@ -30,7 +30,6 @@ extern crate bitcoin;
 extern crate electrumx_client;
 extern crate hex;
 extern crate itertools;
-extern crate time;
 extern crate uuid;
 
 pub mod ecdsa;

--- a/gotham-client/src/main.rs
+++ b/gotham-client/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
             let start = Instant::now();
             wallet.backup(escrow);
 
-            println!("Backup key saved in escrow (Took: {})", start.elapsed().as_secs());
+            println!("Backup key saved in escrow (Took: {})", start.elapsed().as_fractional_secs());
         } else if matches.is_present("verify") {
             let escrow = escrow::Escrow::load();
 
@@ -85,7 +85,7 @@ fn main() {
             let start = Instant::now();
             wallet.verify_backup(escrow);
 
-            println!(" (Took: {})", start.elapsed().as_secs());
+            println!(" (Took: {})", start.elapsed().as_fractional_secs());
         } else if matches.is_present("restore") {
             let escrow = escrow::Escrow::load();
 
@@ -94,7 +94,7 @@ fn main() {
             let start = Instant::now();
             wallet::Wallet::recover_and_save_share(escrow, &network, &client_shim);
 
-            println!(" Backup recovered 💾(Took: {})", start.elapsed().as_secs());
+            println!(" Backup recovered 💾(Took: {})", start.elapsed().as_fractional_secs());
         } else if matches.is_present("rotate") {
             println!("Rotating secret shares");
 
@@ -102,7 +102,7 @@ fn main() {
             let wallet = wallet.rotate(&client_shim);
             wallet.save();
 
-            println!("key rotation complete, (Took: {})", start.elapsed().as_secs());
+            println!("key rotation complete, (Took: {})", start.elapsed().as_fractional_secs());
         } else if matches.is_present("send") {
             if let Some(matches) = matches.subcommand_matches("send") {
                 let to: &str = matches.value_of("to").unwrap();

--- a/gotham-client/src/main.rs
+++ b/gotham-client/src/main.rs
@@ -15,6 +15,7 @@ use client_lib::ClientShim;
 use client_lib::escrow;
 use client_lib::wallet;
 use std::time::Instant;
+use floating_duration::TimeAsFloat;
 
 use std::collections::HashMap;
 

--- a/gotham-client/src/main.rs
+++ b/gotham-client/src/main.rs
@@ -15,7 +15,7 @@ use client_lib::ClientShim;
 use client_lib::escrow;
 use client_lib::wallet;
 use std::time::Instant;
-use floating_duration::TimeAsFloat;
+use floating_duration::TimeFormat;
 
 use std::collections::HashMap;
 
@@ -77,7 +77,7 @@ fn main() {
             let start = Instant::now();
             wallet.backup(escrow);
 
-            println!("Backup key saved in escrow (Took: {})", start.elapsed().as_fractional_secs());
+            println!("Backup key saved in escrow (Took: {})", TimeFormat(start.elapsed()));
         } else if matches.is_present("verify") {
             let escrow = escrow::Escrow::load();
 
@@ -86,7 +86,7 @@ fn main() {
             let start = Instant::now();
             wallet.verify_backup(escrow);
 
-            println!(" (Took: {})", start.elapsed().as_fractional_secs());
+            println!(" (Took: {})", TimeFormat(start.elapsed()));
         } else if matches.is_present("restore") {
             let escrow = escrow::Escrow::load();
 
@@ -95,7 +95,7 @@ fn main() {
             let start = Instant::now();
             wallet::Wallet::recover_and_save_share(escrow, &network, &client_shim);
 
-            println!(" Backup recovered 💾(Took: {})", start.elapsed().as_fractional_secs());
+            println!(" Backup recovered 💾(Took: {})", TimeFormat(start.elapsed()));
         } else if matches.is_present("rotate") {
             println!("Rotating secret shares");
 
@@ -103,7 +103,7 @@ fn main() {
             let wallet = wallet.rotate(&client_shim);
             wallet.save();
 
-            println!("key rotation complete, (Took: {})", start.elapsed().as_fractional_secs());
+            println!("key rotation complete, (Took: {})", TimeFormat(start.elapsed()));
         } else if matches.is_present("send") {
             if let Some(matches) = matches.subcommand_matches("send") {
                 let to: &str = matches.value_of("to").unwrap();

--- a/gotham-client/src/main.rs
+++ b/gotham-client/src/main.rs
@@ -14,7 +14,7 @@ use clap::App;
 use client_lib::ClientShim;
 use client_lib::escrow;
 use client_lib::wallet;
-use time::PreciseTime;
+use std::time::Instant;
 
 use std::collections::HashMap;
 
@@ -73,40 +73,36 @@ fn main() {
 
             println!("Backup private share pending (it can take some time)...");
 
-            let start = PreciseTime::now();
+            let start = Instant::now();
             wallet.backup(escrow);
-            let end = PreciseTime::now();
 
-            println!("Backup key saved in escrow (Took: {})", start.to(end));
+            println!("Backup key saved in escrow (Took: {})", start.elapsed().as_secs());
         } else if matches.is_present("verify") {
             let escrow = escrow::Escrow::load();
 
             println!("verify encrypted backup (it can take some time)...");
 
-            let start = PreciseTime::now();
+            let start = Instant::now();
             wallet.verify_backup(escrow);
-            let end = PreciseTime::now();
 
-            println!(" (Took: {})", start.to(end));
+            println!(" (Took: {})", start.elapsed().as_secs());
         } else if matches.is_present("restore") {
             let escrow = escrow::Escrow::load();
 
             println!("backup recovery in process 📲 (it can take some time)...");
 
-            let start = PreciseTime::now();
+            let start = Instant::now();
             wallet::Wallet::recover_and_save_share(escrow, &network, &client_shim);
-            let end = PreciseTime::now();
 
-            println!(" Backup recovered 💾(Took: {})", start.to(end));
+            println!(" Backup recovered 💾(Took: {})", start.elapsed().as_secs());
         } else if matches.is_present("rotate") {
             println!("Rotating secret shares");
 
-            let start = PreciseTime::now();
+            let start = Instant::now();
             let wallet = wallet.rotate(&client_shim);
             wallet.save();
-            let end = PreciseTime::now();
 
-            println!("key rotation complete, (Took: {})", start.to(end));
+            println!("key rotation complete, (Took: {})", start.elapsed().as_secs());
         } else if matches.is_present("send") {
             if let Some(matches) = matches.subcommand_matches("send") {
                 let to: &str = matches.value_of("to").unwrap();

--- a/gotham-client/src/utilities/requests.rs
+++ b/gotham-client/src/utilities/requests.rs
@@ -7,7 +7,7 @@
 // version 3 of the License, or (at your option) any later version.
 //
 use serde;
-use time::PreciseTime;
+use std::time::Instant;
 use super::super::ClientShim;
 
 pub fn post<V>(client_shim: &ClientShim, path: &str) -> Option<V>
@@ -29,7 +29,7 @@ fn _postb<T, V>(client_shim: &ClientShim, path: &str, body: T) -> Option<V>
         T: serde::ser::Serialize,
         V: serde::de::DeserializeOwned
 {
-    let start = PreciseTime::now();
+    let start = Instant::now();
 
     let mut b = client_shim
         .client
@@ -41,9 +41,7 @@ fn _postb<T, V>(client_shim: &ClientShim, path: &str, body: T) -> Option<V>
 
     let res = b.json(&body).send();
 
-    let end = PreciseTime::now();
-
-    info!("(req {}, took: {})", path, start.to(end));
+    info!("(req {}, took: {})", path, start.elapsed().as_secs());
 
     let value = match res {
         Ok(mut v) => v.text().unwrap(),

--- a/gotham-client/src/utilities/requests.rs
+++ b/gotham-client/src/utilities/requests.rs
@@ -8,7 +8,7 @@
 //
 use serde;
 use std::time::Instant;
-use floating_duration::TimeAsFloat;
+use floating_duration::TimeFormat;
 use super::super::ClientShim;
 
 pub fn post<V>(client_shim: &ClientShim, path: &str) -> Option<V>
@@ -42,7 +42,7 @@ fn _postb<T, V>(client_shim: &ClientShim, path: &str, body: T) -> Option<V>
 
     let res = b.json(&body).send();
 
-    info!("(req {}, took: {})", path, start.elapsed().as_fractional_secs());
+    info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
 
     let value = match res {
         Ok(mut v) => v.text().unwrap(),

--- a/gotham-client/src/utilities/requests.rs
+++ b/gotham-client/src/utilities/requests.rs
@@ -8,6 +8,7 @@
 //
 use serde;
 use std::time::Instant;
+use floating_duration::TimeAsFloat;
 use super::super::ClientShim;
 
 pub fn post<V>(client_shim: &ClientShim, path: &str) -> Option<V>
@@ -41,7 +42,7 @@ fn _postb<T, V>(client_shim: &ClientShim, path: &str, body: T) -> Option<V>
 
     let res = b.json(&body).send();
 
-    info!("(req {}, took: {})", path, start.elapsed().as_secs());
+    info!("(req {}, took: {})", path, start.elapsed().as_fractional_secs());
 
     let value = match res {
         Ok(mut v) => v.text().unwrap(),

--- a/gotham-server/Cargo.toml
+++ b/gotham-server/Cargo.toml
@@ -26,7 +26,6 @@ rusoto_dynamodb = "0.36.0"
 rusoto_core = "0.36.0"
 time-test = "0.2.1"
 log = "0.4"
-time = "*"
 config = "0.9.2"
 uuid = { version = "0.7", features = ["v4"] }
 error-chain = "0.12.0"

--- a/gotham-server/Cargo.toml
+++ b/gotham-server/Cargo.toml
@@ -33,6 +33,7 @@ failure = "0.1.5"
 jsonwebtoken = "6.0.1"
 rust-crypto = "0.2"
 hex = "0.3.2"
+floating-duration = "0.1.2"
 
 [dependencies.zk-paillier]
 git = "https://github.com/KZen-networks/zk-paillier"

--- a/gotham-server/src/lib.rs
+++ b/gotham-server/src/lib.rs
@@ -36,7 +36,6 @@ extern crate log;
 #[cfg(test)]
 #[macro_use]
 extern crate time_test;
-extern crate time;
 
 extern crate crypto;
 extern crate jsonwebtoken as jwt;

--- a/gotham-server/src/lib.rs
+++ b/gotham-server/src/lib.rs
@@ -36,6 +36,7 @@ extern crate log;
 #[cfg(test)]
 #[macro_use]
 extern crate time_test;
+extern crate floating_duration;
 
 extern crate crypto;
 extern crate jsonwebtoken as jwt;

--- a/gotham-server/src/tests.rs
+++ b/gotham-server/src/tests.rs
@@ -39,7 +39,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 first message", start.elapsed().as_fractional_secs());
+        println!("{} Network/Server: party1 first message", TimeFormat(start.elapsed()));
 
         let res_body = response.body_string().unwrap();
         let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
@@ -50,7 +50,7 @@ mod tests {
         let (kg_party_two_first_message, kg_ec_key_pair_party2) =
             MasterKey2::key_gen_first_message();
 
-        println!("{} Client: party2 first message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 first message", TimeFormat(start.elapsed()));
         /*************** END: FIRST MESSAGE ***************/
 
         /*************** START: SECOND MESSAGE ***************/
@@ -65,7 +65,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 second message", start.elapsed().as_fractional_secs());
+        println!("{} Network/Server: party1 second message", TimeFormat(start.elapsed()));
 
         let res_body = response.body_string().unwrap();
         let kg_party_one_second_message: party1::KeyGenParty1Message2 =
@@ -79,7 +79,7 @@ mod tests {
         );
         assert!(key_gen_second_message.is_ok());
 
-        println!("{} Client: party2 second message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 second message", TimeFormat(start.elapsed()));
 
         let (party_two_second_message, party_two_paillier, party_two_pdl_chal) =
             key_gen_second_message.unwrap();
@@ -97,7 +97,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 third message", start.elapsed().as_fractional_secs());
+        println!("{} Network/Server: party1 third message", TimeFormat(start.elapsed()));
 
         let res_body = response.body_string().unwrap();
         let party_one_third_message: party_one::PDLFirstMessage =
@@ -107,7 +107,7 @@ mod tests {
 
         let pdl_decom_party2 = MasterKey2::key_gen_third_message(&party_two_pdl_chal);
 
-        println!("{} Client: party2 third message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 third message", TimeFormat(start.elapsed()));
         /*************** END: THIRD MESSAGE ***************/
 
         /*************** START: FOURTH MESSAGE ***************/
@@ -125,7 +125,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 fourth message", start.elapsed().as_fractional_secs());
+        println!("{} Network/Server: party1 fourth message", TimeFormat(start.elapsed()));
 
         let res_body = response.body_string().unwrap();
         let party_one_pdl_second_message: party_one::PDLSecondMessage =
@@ -140,7 +140,7 @@ mod tests {
         )
         .expect("pdl error party1");
 
-        println!("{} Client: party2 fourth message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 fourth message", TimeFormat(start.elapsed()));
         /*************** END: FOURTH MESSAGE ***************/
 
         /*************** START: CHAINCODE FIRST MESSAGE ***************/
@@ -154,7 +154,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 chain code first message",
-            start.elapsed().as_fractional_secs()
+            TimeFormat(start.elapsed())
         );
 
         let res_body = response.body_string().unwrap();
@@ -165,7 +165,7 @@ mod tests {
         let (cc_party_two_first_message, cc_ec_key_pair2) =
             chain_code::party2::ChainCode2::chain_code_first_message();
 
-        println!("{} Client: party2 chain code first message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 chain code first message", TimeFormat(start.elapsed()));
         /*************** END: CHAINCODE FIRST MESSAGE ***************/
 
         /*************** START: CHAINCODE SECOND MESSAGE ***************/
@@ -182,7 +182,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 chain code second message",
-            start.elapsed().as_fractional_secs()
+            TimeFormat(start.elapsed())
         );
 
         let res_body = response.body_string().unwrap();
@@ -196,7 +196,7 @@ mod tests {
                 &cc_party_one_second_message,
             );
 
-        println!("{} Client: party2 chain code second message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 chain code second message", TimeFormat(start.elapsed()));
         /*************** END: CHAINCODE SECOND MESSAGE ***************/
 
         let start = Instant::now();
@@ -206,7 +206,7 @@ mod tests {
         )
         .chain_code;
 
-        println!("{} Client: party2 chain code second message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 chain code second message", TimeFormat(start.elapsed()));
         /*************** END: CHAINCODE COMPUTE MESSAGE ***************/
 
         let start = Instant::now();
@@ -220,7 +220,7 @@ mod tests {
             &party_two_paillier,
         );
 
-        println!("{} Client: party2 master_key", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 master_key", TimeFormat(start.elapsed()));
         /*************** END: MASTER KEYS MESSAGE ***************/
 
         (id, party_two_master_key)
@@ -251,7 +251,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 sign first message",
-            start.elapsed().as_fractional_secs()
+            TimeFormat(start.elapsed())
         );
 
         let res_body = response.body_string().unwrap();
@@ -272,7 +272,7 @@ mod tests {
             &message,
         );
 
-        println!("{} Client: party2 sign second message", start.elapsed().as_fractional_secs());
+        println!("{} Client: party2 sign second message", TimeFormat(start.elapsed()));
 
         let request: ecdsa::SignSecondMsgRequest = ecdsa::SignSecondMsgRequest {
             message,
@@ -294,7 +294,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 sign second message",
-            start.elapsed().as_fractional_secs()
+            TimeFormat(start.elapsed())
         );
 
         let res_body = response.body_string().unwrap();

--- a/gotham-server/src/tests.rs
+++ b/gotham-server/src/tests.rs
@@ -39,7 +39,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 first message", start.elapsed().as_secs());
+        println!("{} Network/Server: party1 first message", start.elapsed().as_fractional_secs());
 
         let res_body = response.body_string().unwrap();
         let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
@@ -50,7 +50,7 @@ mod tests {
         let (kg_party_two_first_message, kg_ec_key_pair_party2) =
             MasterKey2::key_gen_first_message();
 
-        println!("{} Client: party2 first message", start.elapsed().as_secs());
+        println!("{} Client: party2 first message", start.elapsed().as_fractional_secs());
         /*************** END: FIRST MESSAGE ***************/
 
         /*************** START: SECOND MESSAGE ***************/
@@ -65,7 +65,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 second message", start.elapsed().as_secs());
+        println!("{} Network/Server: party1 second message", start.elapsed().as_fractional_secs());
 
         let res_body = response.body_string().unwrap();
         let kg_party_one_second_message: party1::KeyGenParty1Message2 =
@@ -79,7 +79,7 @@ mod tests {
         );
         assert!(key_gen_second_message.is_ok());
 
-        println!("{} Client: party2 second message", start.elapsed().as_secs());
+        println!("{} Client: party2 second message", start.elapsed().as_fractional_secs());
 
         let (party_two_second_message, party_two_paillier, party_two_pdl_chal) =
             key_gen_second_message.unwrap();
@@ -97,7 +97,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 third message", start.elapsed().as_secs());
+        println!("{} Network/Server: party1 third message", start.elapsed().as_fractional_secs());
 
         let res_body = response.body_string().unwrap();
         let party_one_third_message: party_one::PDLFirstMessage =
@@ -107,7 +107,7 @@ mod tests {
 
         let pdl_decom_party2 = MasterKey2::key_gen_third_message(&party_two_pdl_chal);
 
-        println!("{} Client: party2 third message", start.elapsed().as_secs());
+        println!("{} Client: party2 third message", start.elapsed().as_fractional_secs());
         /*************** END: THIRD MESSAGE ***************/
 
         /*************** START: FOURTH MESSAGE ***************/
@@ -125,7 +125,7 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        println!("{} Network/Server: party1 fourth message", start.elapsed().as_secs());
+        println!("{} Network/Server: party1 fourth message", start.elapsed().as_fractional_secs());
 
         let res_body = response.body_string().unwrap();
         let party_one_pdl_second_message: party_one::PDLSecondMessage =
@@ -140,7 +140,7 @@ mod tests {
         )
         .expect("pdl error party1");
 
-        println!("{} Client: party2 fourth message", start.elapsed().as_secs());
+        println!("{} Client: party2 fourth message", start.elapsed().as_fractional_secs());
         /*************** END: FOURTH MESSAGE ***************/
 
         /*************** START: CHAINCODE FIRST MESSAGE ***************/
@@ -154,7 +154,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 chain code first message",
-            start.elapsed().as_secs()
+            start.elapsed().as_fractional_secs()
         );
 
         let res_body = response.body_string().unwrap();
@@ -165,7 +165,7 @@ mod tests {
         let (cc_party_two_first_message, cc_ec_key_pair2) =
             chain_code::party2::ChainCode2::chain_code_first_message();
 
-        println!("{} Client: party2 chain code first message", start.elapsed().as_secs());
+        println!("{} Client: party2 chain code first message", start.elapsed().as_fractional_secs());
         /*************** END: CHAINCODE FIRST MESSAGE ***************/
 
         /*************** START: CHAINCODE SECOND MESSAGE ***************/
@@ -182,7 +182,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 chain code second message",
-            start.elapsed().as_secs()
+            start.elapsed().as_fractional_secs()
         );
 
         let res_body = response.body_string().unwrap();
@@ -196,7 +196,7 @@ mod tests {
                 &cc_party_one_second_message,
             );
 
-        println!("{} Client: party2 chain code second message", start.elapsed().as_secs());
+        println!("{} Client: party2 chain code second message", start.elapsed().as_fractional_secs());
         /*************** END: CHAINCODE SECOND MESSAGE ***************/
 
         let start = Instant::now();
@@ -206,7 +206,7 @@ mod tests {
         )
         .chain_code;
 
-        println!("{} Client: party2 chain code second message", start.elapsed().as_secs());
+        println!("{} Client: party2 chain code second message", start.elapsed().as_fractional_secs());
         /*************** END: CHAINCODE COMPUTE MESSAGE ***************/
 
         let start = Instant::now();
@@ -220,7 +220,7 @@ mod tests {
             &party_two_paillier,
         );
 
-        println!("{} Client: party2 master_key", start.elapsed().as_secs());
+        println!("{} Client: party2 master_key", start.elapsed().as_fractional_secs());
         /*************** END: MASTER KEYS MESSAGE ***************/
 
         (id, party_two_master_key)
@@ -251,7 +251,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 sign first message",
-            start.elapsed().as_secs()
+            start.elapsed().as_fractional_secs()
         );
 
         let res_body = response.body_string().unwrap();
@@ -272,7 +272,7 @@ mod tests {
             &message,
         );
 
-        println!("{} Client: party2 sign second message", start.elapsed().as_secs());
+        println!("{} Client: party2 sign second message", start.elapsed().as_fractional_secs());
 
         let request: ecdsa::SignSecondMsgRequest = ecdsa::SignSecondMsgRequest {
             message,
@@ -294,7 +294,7 @@ mod tests {
 
         println!(
             "{} Network/Server: party1 sign second message",
-            start.elapsed().as_secs()
+            start.elapsed().as_fractional_secs()
         );
 
         let res_body = response.body_string().unwrap();

--- a/gotham-server/src/tests.rs
+++ b/gotham-server/src/tests.rs
@@ -18,7 +18,7 @@ mod tests {
     use rocket::local::Client;
     use serde_json;
     use std::env;
-    use time::PreciseTime;
+    use std::time::Instant;
 
     use curv::arithmetic::traits::Converter;
     use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
@@ -31,7 +31,7 @@ mod tests {
         time_test!();
 
         /*************** START: FIRST MESSAGE ***************/
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post("/ecdsa/keygen/first")
@@ -39,26 +39,24 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
-        println!("{} Network/Server: party1 first message", start.to(end));
+        println!("{} Network/Server: party1 first message", start.elapsed().as_secs());
 
         let res_body = response.body_string().unwrap();
         let (id, kg_party_one_first_message): (String, party_one::KeyGenFirstMsg) =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let (kg_party_two_first_message, kg_ec_key_pair_party2) =
             MasterKey2::key_gen_first_message();
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 first message", start.to(end));
+        println!("{} Client: party2 first message", start.elapsed().as_secs());
         /*************** END: FIRST MESSAGE ***************/
 
         /*************** START: SECOND MESSAGE ***************/
         let body = serde_json::to_string(&kg_party_two_first_message.d_log_proof).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/keygen/{}/second", id))
@@ -67,14 +65,13 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
-        println!("{} Network/Server: party1 second message", start.to(end));
+        println!("{} Network/Server: party1 second message", start.elapsed().as_secs());
 
         let res_body = response.body_string().unwrap();
         let kg_party_one_second_message: party1::KeyGenParty1Message2 =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let key_gen_second_message = MasterKey2::key_gen_second_message(
             &kg_party_one_first_message,
@@ -82,8 +79,7 @@ mod tests {
         );
         assert!(key_gen_second_message.is_ok());
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 second message", start.to(end));
+        println!("{} Client: party2 second message", start.elapsed().as_secs());
 
         let (party_two_second_message, party_two_paillier, party_two_pdl_chal) =
             key_gen_second_message.unwrap();
@@ -92,7 +88,7 @@ mod tests {
         /*************** START: THIRD MESSAGE ***************/
         let body = serde_json::to_string(&party_two_second_message.pdl_first_message).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/keygen/{}/third", id))
@@ -101,19 +97,17 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
-        println!("{} Network/Server: party1 third message", start.to(end));
+        println!("{} Network/Server: party1 third message", start.elapsed().as_secs());
 
         let res_body = response.body_string().unwrap();
         let party_one_third_message: party_one::PDLFirstMessage =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let pdl_decom_party2 = MasterKey2::key_gen_third_message(&party_two_pdl_chal);
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 third message", start.to(end));
+        println!("{} Client: party2 third message", start.elapsed().as_secs());
         /*************** END: THIRD MESSAGE ***************/
 
         /*************** START: FOURTH MESSAGE ***************/
@@ -122,7 +116,7 @@ mod tests {
         let request = party_2_pdl_second_message;
         let body = serde_json::to_string(&request).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/keygen/{}/fourth", id))
@@ -131,14 +125,13 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
-        println!("{} Network/Server: party1 fourth message", start.to(end));
+        println!("{} Network/Server: party1 fourth message", start.elapsed().as_secs());
 
         let res_body = response.body_string().unwrap();
         let party_one_pdl_second_message: party_one::PDLSecondMessage =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         MasterKey2::key_gen_fourth_message(
             &party_two_pdl_chal,
@@ -147,12 +140,11 @@ mod tests {
         )
         .expect("pdl error party1");
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 fourth message", start.to(end));
+        println!("{} Client: party2 fourth message", start.elapsed().as_secs());
         /*************** END: FOURTH MESSAGE ***************/
 
         /*************** START: CHAINCODE FIRST MESSAGE ***************/
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/keygen/{}/chaincode/first", id))
@@ -160,27 +152,26 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
         println!(
             "{} Network/Server: party1 chain code first message",
-            start.to(end)
+            start.elapsed().as_secs()
         );
 
         let res_body = response.body_string().unwrap();
         let cc_party_one_first_message: Party1FirstMessage =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
         let (cc_party_two_first_message, cc_ec_key_pair2) =
             chain_code::party2::ChainCode2::chain_code_first_message();
-        let end = PreciseTime::now();
-        println!("{} Client: party2 chain code first message", start.to(end));
+
+        println!("{} Client: party2 chain code first message", start.elapsed().as_secs());
         /*************** END: CHAINCODE FIRST MESSAGE ***************/
 
         /*************** START: CHAINCODE SECOND MESSAGE ***************/
         let body = serde_json::to_string(&cc_party_two_first_message.d_log_proof).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/keygen/{}/chaincode/second", id))
@@ -189,42 +180,36 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
         println!(
             "{} Network/Server: party1 chain code second message",
-            start.to(end)
+            start.elapsed().as_secs()
         );
 
         let res_body = response.body_string().unwrap();
         let cc_party_one_second_message: Party1SecondMessage =
             serde_json::from_str(&res_body).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
         let _cc_party_two_second_message =
             chain_code::party2::ChainCode2::chain_code_second_message(
                 &cc_party_one_first_message,
                 &cc_party_one_second_message,
             );
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 chain code second message", start.to(end));
+        println!("{} Client: party2 chain code second message", start.elapsed().as_secs());
         /*************** END: CHAINCODE SECOND MESSAGE ***************/
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
         let party2_cc = chain_code::party2::ChainCode2::compute_chain_code(
             &cc_ec_key_pair2,
             &cc_party_one_second_message.comm_witness.public_share,
         )
         .chain_code;
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 chain code second message", start.to(end));
+        println!("{} Client: party2 chain code second message", start.elapsed().as_secs());
         /*************** END: CHAINCODE COMPUTE MESSAGE ***************/
 
-        let end = PreciseTime::now();
-        println!("{} Network/Server: party1 master key", start.to(end));
-
-        let start = PreciseTime::now();
+        let start = Instant::now();
         let party_two_master_key = MasterKey2::set_master_key(
             &party2_cc,
             &kg_ec_key_pair_party2,
@@ -235,8 +220,7 @@ mod tests {
             &party_two_paillier,
         );
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 master_key", start.to(end));
+        println!("{} Client: party2 master_key", start.elapsed().as_secs());
         /*************** END: MASTER KEYS MESSAGE ***************/
 
         (id, party_two_master_key)
@@ -256,7 +240,7 @@ mod tests {
 
         let body = serde_json::to_string(&request).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/sign/{}/first", id))
@@ -265,10 +249,9 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
         println!(
             "{} Network/Server: party1 sign first message",
-            start.to(end)
+            start.elapsed().as_secs()
         );
 
         let res_body = response.body_string().unwrap();
@@ -280,7 +263,7 @@ mod tests {
 
         let child_party_two_master_key = master_key_2.get_child(vec![x_pos.clone(), y_pos.clone()]);
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let party_two_sign_message = child_party_two_master_key.sign_second_message(
             &eph_ec_key_pair_party2,
@@ -289,8 +272,7 @@ mod tests {
             &message,
         );
 
-        let end = PreciseTime::now();
-        println!("{} Client: party2 sign second message", start.to(end));
+        println!("{} Client: party2 sign second message", start.elapsed().as_secs());
 
         let request: ecdsa::SignSecondMsgRequest = ecdsa::SignSecondMsgRequest {
             message,
@@ -301,7 +283,7 @@ mod tests {
 
         let body = serde_json::to_string(&request).unwrap();
 
-        let start = PreciseTime::now();
+        let start = Instant::now();
 
         let mut response = client
             .post(format!("/ecdsa/sign/{}/second", id))
@@ -310,10 +292,9 @@ mod tests {
             .dispatch();
         assert_eq!(response.status(), Status::Ok);
 
-        let end = PreciseTime::now();
         println!(
             "{} Network/Server: party1 sign second message",
-            start.to(end)
+            start.elapsed().as_secs()
         );
 
         let res_body = response.body_string().unwrap();


### PR DESCRIPTION
gotham-client compilation (cargo build) was failing with the rust nightly version detailed in gotham-server's Docker file (nightly-2019-07-09), apparently due to a "loose" dependency on `time` crate:
```
error[E0277]: `time::Duration` doesn't implement `std::fmt::Display`
  --> src/utilities/requests.rs:46:39
   |
46 |     info!("(req {}, took: {})", path, start.to(end));
   |                                       ^^^^^^^^^^^^^ `time::Duration` cannot be formatted with the default formatter
```
Moreover, the use of `time::PreciseTime` is deprecated:
```
warning: use of deprecated item 'time::PreciseTime': Use `Instant`
  --> src/utilities/requests.rs:32:17
   |
32 |     let start = PreciseTime::now();
   |                 ^^^^^^^^^^^^^^^^
```
This PR replaces the `time` crate with `std::Instant` and also adds .travis.yml to ensure tracking of successful/failed builds with respect to the same rust nightly version, and more transparency.
