### PR TITLE
Fix Travis CI icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/KZen-networks/gotham-city.svg?branch=master)](https://travis-ci.com/KZen-networks/gotham-city)
+[![Build Status](https://travis-ci.org/KZen-networks/gotham-city.svg?branch=master)](https://travis-ci.org/KZen-networks/gotham-city)
 
 Gotham City
 =====================================

--- a/gotham-client/Cargo.toml
+++ b/gotham-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotham-client"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "gbenattar <g.benattar@gmail.com>",
     "Oded Leiba <odedleiba5@gmail.com"

--- a/gotham-server/Cargo.toml
+++ b/gotham-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotham-server"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "gbenattar <g.benattar@gmail.com>",
     "Oded Leiba <odedleiba5@gmail.com"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["oleiba <oded@kzencorp.com>"]
 edition = "2018"
 


### PR DESCRIPTION
changed travis-ci.**com** (which is payed, and for private repositories) to travis-ci.**org** (which is free, and for open-source repositories)